### PR TITLE
Fix ui bug when the person's name is too long

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,7 +28,12 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="nusId" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="nusId" text="\$first" styleClass="cell_big_label" >
+            <minWidth>
+                <!-- Ensures that the label text is never truncated -->
+                <Region fx:constant="USE_PREF_SIZE" />
+            </minWidth>
+        </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
 
         <!-- Spacer for aligning the tag at the right -->
@@ -38,6 +43,10 @@
           <padding>
             <Insets top="0.42" right="4.20" bottom="0.42" left="4.20" />
           </padding>
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
         </Label>
       </HBox>
       <FlowPane fx:id="groups" hgap="8" />


### PR DESCRIPTION
Person name will still be truncated.
NusId and Tag will remain visible even with long names.