### PR TITLE
Inform users of empty params and relax search requirements

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -23,9 +23,9 @@ public class FindCommand extends Command {
     public static final String NOT_REQUIRED_VALUE = "$$NOT_REQUIRED$$";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " n/alice bob charlie";
+            + "the specified keywords (case-insensitive) and displays them as a list.\n"
+            + "Parameters: KEYWORD [id/NUSID] [n/NAME] [e/EMAIL] [p/PHONE_NUMBER] [t/TAG] [g/GROUP]...\n"
+            + "Example: " + COMMAND_WORD + " n/Peter Parker " + "g/CS2101";
 
     private final NusIdMatchesPredicate nusIdPredicate;
     private final NameContainsKeywordsPredicate namePredicate;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -53,6 +53,10 @@ public class FindCommandParser implements Parser<FindCommand> {
         String tagToMatch = argumentMultimap.getValue(PREFIX_TAG).orElse(NOT_REQUIRED_VALUE);
         List<String> groupToMatch = argumentMultimap.getAllValues(PREFIX_GROUP);
 
+        if (someParameterIsEmpty(groupToMatch, nusIdToMatch, nameToMatch, phoneToMatch, emailToMatch, tagToMatch)) {
+            throw new ParseException(buildErrorMessage(nusIdToMatch, nameToMatch, phoneToMatch,
+                    emailToMatch, tagToMatch, groupToMatch));
+        }
 
         String[] nameKeywords = nameToMatch.split("\\s+");
 
@@ -64,4 +68,62 @@ public class FindCommandParser implements Parser<FindCommand> {
                 new TagMatchesPredicate(tagToMatch));
     }
 
+    private String buildErrorMessage(String id, String name, String phone,
+                                     String email, String tag, List<String> groups) {
+        // Stop user from entering a command if any field is empty
+        StringBuilder errorMessage = new StringBuilder();
+        errorMessage.append("The provided fields should not be empty: ");
+        if (id.isBlank()) {
+            errorMessage.append("[id/NUSID] ");
+        }
+
+        if (name.isBlank()) {
+            errorMessage.append("[n/NAME] ");
+        }
+
+        if (phone.isBlank()) {
+            errorMessage.append("[p/PHONE_NUMBER] ");
+        }
+
+        if (email.isBlank()) {
+            errorMessage.append("[e/EMAIL] ");
+        }
+
+        if (tag.isBlank()) {
+            errorMessage.append("[t/TAG] ");
+        }
+
+        boolean someGroupIsEmpty = false;
+        for (String group : groups) {
+            if (group.isBlank()) {
+                someGroupIsEmpty = true;
+                break;
+            }
+        }
+
+        if (someGroupIsEmpty) {
+            errorMessage.append("[g/GROUP]...");
+        }
+
+        return errorMessage.toString();
+    }
+
+    private boolean someParameterIsEmpty(List<String> groups, String... params) {
+        boolean hasEmptyParams = false;
+        for (String group : groups) {
+            if (group.isBlank()) {
+                hasEmptyParams = true;
+                break;
+            }
+        }
+
+        for (String param : params) {
+            if (param.isBlank()) {
+                hasEmptyParams = true;
+                break;
+            }
+        }
+
+        return hasEmptyParams;
+    }
 }

--- a/src/main/java/seedu/address/model/person/NusIdMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/NusIdMatchesPredicate.java
@@ -20,7 +20,7 @@ public class NusIdMatchesPredicate implements Predicate<Person> {
         if (keyword.equals(FindCommand.NOT_REQUIRED_VALUE)) {
             return true;
         } else if (NusId.isValidFindNusId(keyword)) {
-            return person.getNusId().toString().startsWith(keyword.trim());
+            return person.getNusId().toString().toLowerCase().startsWith(keyword.trim().toLowerCase());
         } else {
             return false;
         }


### PR DESCRIPTION
Previously an empty param gave uninformative error messages or straight up caused exceptions.

Fix such inconsistencies.